### PR TITLE
adhoc conferences: remove trailing comma

### DIFF
--- a/wazo_calld_client/commands/adhoc_conferences.py
+++ b/wazo_calld_client/commands/adhoc_conferences.py
@@ -9,9 +9,7 @@ class AdhocConferencesCommand(CalldCommand):
     resource = 'adhoc_conferences'
     headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 
-    def create_from_user(
-        self, host_call_id, *participant_call_ids,
-    ):
+    def create_from_user(self, host_call_id, *participant_call_ids):
         body = {
             'host_call_id': host_call_id,
             'participant_call_ids': participant_call_ids,


### PR DESCRIPTION
Reason: it is a syntax error on Python2.x when the last param
is a *args