### PR TITLE
Remove Python 2 clients and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ c.meetings.user_kick_participant(meeting_uuid, participant_id)  # user may only 
 
 ```
 pip install tox
-tox --recreate -e py27
+tox --recreate -e py37
 ```
 
 ## How to implement a new command

--- a/debian/control
+++ b/debian/control
@@ -5,29 +5,10 @@ Maintainer: Wazo Maintainers <dev@wazo.community>
 Build-Depends:
  debhelper (>= 9),
  dh-python,
- python-all (>= 2.7),
- python-setuptools,
  python3-all,
  python3-setuptools
 Standards-Version: 4.2.1
-X-Python-Version: >= 2.7
-X-Python3-Version: >= 3.5
-
-Package: wazo-calld-client
-Architecture: all
-Section: python
-Depends:
- ${python:Depends},
- ${misc:Depends},
- wazo-lib-rest-client,
- python-requests,
- python-stevedore
-Provides: xivo-ctid-ng-client
-Replaces: xivo-ctid-ng-client
-Conflicts: xivo-ctid-ng-client
-Description: wazo-calld client library in python
- Wazo is a system based on a powerful IPBX, to bring an easy to
- install solution for telephony and related services.
+X-Python3-Version: >= 3.7
 
 Package: wazo-calld-client-python3
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,8 @@
 # -*- makefile -*-
 
 export PYBUILD_NAME=wazo_calld_client
-export PYBUILD_DESTDIR_python2=debian/wazo-calld-client/
 export PYBUILD_DESTDIR_python3=debian/wazo-calld-client-python3/
 export PYBUILD_DISABLE=test
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+#!/usr/bin/env python3
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import setup, find_packages

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 pytest
-mock
-pyhamcrest<1.10.0  # to support python 2.7
+pyhamcrest

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py37, pycodestyle, pylint
+envlist = py37, pycodestyle, pylint
 skipsdist = True
 
 [testenv]

--- a/wazo_calld_client/__init__.py
+++ b/wazo_calld_client/__init__.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_calld_client.client import CalldClient as Client  # noqa

--- a/wazo_calld_client/client.py
+++ b/wazo_calld_client/client.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_lib_rest_client.client import BaseClient
@@ -10,6 +9,4 @@ class CalldClient(BaseClient):
     namespace = 'wazo_calld_client.commands'
 
     def __init__(self, host, port=443, prefix='/api/calld', version='1.0', **kwargs):
-        super(CalldClient, self).__init__(
-            host=host, port=port, prefix=prefix, version=version, **kwargs
-        )
+        super().__init__(host=host, port=port, prefix=prefix, version=version, **kwargs)

--- a/wazo_calld_client/command.py
+++ b/wazo_calld_client/command.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_lib_rest_client.command import RESTCommand

--- a/wazo_calld_client/commands/applications.py
+++ b/wazo_calld_client/commands/applications.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/calls.py
+++ b/wazo_calld_client/commands/calls.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/conferences.py
+++ b/wazo_calld_client/commands/conferences.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/config.py
+++ b/wazo_calld_client/commands/config.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 

--- a/wazo_calld_client/commands/faxes.py
+++ b/wazo_calld_client/commands/faxes.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/lines.py
+++ b/wazo_calld_client/commands/lines.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/meetings.py
+++ b/wazo_calld_client/commands/meetings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_calld_client/commands/relocates.py
+++ b/wazo_calld_client/commands/relocates.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/switchboards.py
+++ b/wazo_calld_client/commands/switchboards.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/tests/test_calls.py
+++ b/wazo_calld_client/commands/tests/test_calls.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that

--- a/wazo_calld_client/commands/tests/test_switchboards.py
+++ b/wazo_calld_client/commands/tests/test_switchboards.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that

--- a/wazo_calld_client/commands/tests/test_transfers.py
+++ b/wazo_calld_client/commands/tests/test_transfers.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that

--- a/wazo_calld_client/commands/tests/test_voicemails.py
+++ b/wazo_calld_client/commands/tests/test_voicemails.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
 from hamcrest import equal_to
-from mock import ANY
+from unittest.mock import ANY
 from wazo_lib_rest_client.tests.command import RESTCommandTestCase
 
 from ..voicemails import VoicemailsCommand

--- a/wazo_calld_client/commands/transfers.py
+++ b/wazo_calld_client/commands/transfers.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/trunks.py
+++ b/wazo_calld_client/commands/trunks.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/commands/voicemails.py
+++ b/wazo_calld_client/commands/voicemails.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand

--- a/wazo_calld_client/exceptions.py
+++ b/wazo_calld_client/exceptions.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from requests import HTTPError
@@ -21,8 +20,8 @@ class CalldError(HTTPError):
         except KeyError:
             raise InvalidCalldError()
 
-        exception_message = '{e.message}: {e.details}'.format(e=self)
-        super(CalldError, self).__init__(exception_message, response=response)
+        exception_message = f'{self.message}: {self.details}'
+        super().__init__(exception_message, response=response)
 
 
 class InvalidCalldError(Exception):

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,6 +1,5 @@
 - project:
     templates:
       - wazo-tox-linters
-      - wazo-tox-py27
       - wazo-tox-py37
       - debian-packaging-template


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-lib-rest-client/pull/12