### PR TITLE
Use Python 3.9, new workers, and Bullseye dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,4 @@
 .coverage
 .tox
 coverage.xml
-pycodestyle.txt
-pylint.txt
 unit-tests.xml

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ c.meetings.user_kick_participant(meeting_uuid, participant_id)  # user may only 
 
 ```
 pip install tox
-tox --recreate -e py37
+tox --recreate -e py39
 ```
 
 ## How to implement a new command

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  python3-all,
  python3-setuptools
 Standards-Version: 4.2.1
-X-Python3-Version: >= 3.7
+X-Python3-Version: >= 3.9
 
 Package: wazo-calld-client-python3
 Architecture: all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
-requests==2.21.0
-stevedore==1.29.0
+requests==2.25.1
+stevedore==3.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, pycodestyle, pylint
+envlist = py39, linters
 skipsdist = True
 
 [testenv]
@@ -15,34 +15,14 @@ deps =
     -rtest-requirements.txt
     pytest-cov
 
-[testenv:pycodestyle]
-# E501: line too long (80 chars)
-commands =
-    -sh -c 'pycodestyle --ignore=E501 wazo_calld_client > pycodestyle.txt'
-deps =
-    pycodestyle
-allowlist_externals =
-    sh
-
-[testenv:pylint]
-commands =
-    -sh -c 'pylint --rcfile=/usr/share/xivo-ci/pylintrc wazo_calld_client > pylint.txt'
-deps =
-    -rrequirements.txt
-    -rtest-requirements.txt
-    pylint
-allowlist_externals =
-    sh
-
 [testenv:black]
 skip_install = true
-basepython = python3
 deps = black
 commands = black --skip-string-normalization .
 
 [testenv:linters]
+basepython = python3.10
 skip_install = true
-basepython = python3
 deps = flake8
        flake8-colors
        black

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,5 +1,5 @@
 - project:
     templates:
-      - wazo-tox-linters
-      - wazo-tox-py37
-      - debian-packaging-template
+      - wazo-tox-linters-310
+      - wazo-tox-py39
+      - debian-packaging-bullseye


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-lib-rest-client/pull/14