### PR TITLE
mypy: use default import following policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,4 @@ python_version = "3.10"
 show_error_codes = true
 check_untyped_defs = true
 warn_unused_configs = true
-follow_imports = "skip"
 ignore_missing_imports = true


### PR DESCRIPTION
Why:

* This option makes pre-commit miss some typing errors