### PR TITLE
pre-commit: bump mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: wazo-copyright-check
   # Automatically check typing using MyPy
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.19.1
     hooks:
       - id: mypy
         language_version: '3.11'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates typing checks in pre-commit to a newer mypy.
> 
> - Bumps `pre-commit` hook `mirrors-mypy` from `v0.991` to `v1.19.1` in `.pre-commit-config.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d8fa91fba5d041820846d5a1983789a24971732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->