### PR TITLE
voicemails: list voicemail messages (admin)

### DIFF
--- a/wazo_calld_client/commands/tests/test_voicemails.py
+++ b/wazo_calld_client/commands/tests/test_voicemails.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import ANY
@@ -93,6 +93,32 @@ class TestVoicemails(RESTCommandTestCase):
             ANY,
             headers={'Accept': 'application/json'},
             params={'voicemail_type': 'all'},
+        )
+        assert_that(result, equal_to({'return': 'value'}))
+
+    def test_list_voicemail_messages(self):
+        self.session.get.return_value = self.new_response(200, json={'return': 'value'})
+
+        result = self.command.list_voicemail_messages(
+            voicemail_type='personal', limit=10
+        )
+
+        self.session.get.assert_called_once_with(
+            ANY,
+            headers={'Accept': 'application/json'},
+            params={'voicemail_type': 'personal', 'limit': 10},
+        )
+        assert_that(result, equal_to({'return': 'value'}))
+
+    def test_list_voicemail_messages_no_params(self):
+        self.session.get.return_value = self.new_response(200, json={'return': 'value'})
+
+        result = self.command.list_voicemail_messages()
+
+        self.session.get.assert_called_once_with(
+            ANY,
+            headers={'Accept': 'application/json'},
+            params={},
         )
         assert_that(result, equal_to({'return': 'value'}))
 

--- a/wazo_calld_client/commands/voicemails.py
+++ b/wazo_calld_client/commands/voicemails.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..command import CalldCommand
@@ -35,6 +35,10 @@ class VoicemailsCommand(CalldCommand):
     def list_voicemail_messages_from_user(self, voicemail_type='all', **params):
         url = self._client.url('users', 'me', 'voicemails', 'messages')
         return self._get(url, params | {"voicemail_type": voicemail_type})
+
+    def list_voicemail_messages(self, **params):
+        url = self._client.url(self.resource, 'messages')
+        return self._get(url, params)
 
     def delete_voicemail_message(self, voicemail_id, message_id):
         headers = self._get_headers()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a small new client method for listing voicemail messages and accompanying unit tests; minimal surface-area change and no auth/security logic is modified.
> 
> **Overview**
> Adds an *admin-style* voicemail message listing call via new `VoicemailsCommand.list_voicemail_messages()` that GETs `voicemails/messages` with optional query params.
> 
> Extends `test_voicemails.py` with coverage for the new method (with and without params), and updates copyright headers to 2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2157f007820496cee614faac8c93955a636abcea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->